### PR TITLE
Updated the QGIS Resource Sharing Plugin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ You can clone this repository and import the styles via Style Manager.
 Click the image below to open a short YouTube video that shows you how to import the styles directly from an URL.
 [![Check instructions for style import from this video](http://i3.ytimg.com/vi/zZW97unRBRw/maxresdefault.jpg)](https://www.youtube.com/watch?v=zZW97unRBRw)
 
-You can also use [QGIS Resource Sharing plugin](http://qgis-contribution.github.io/QGIS-ResourceSharing/author/repository-structure.html)
+You can also use [QGIS Resource Sharing plugin](http://qgis-contribution.github.io/QGIS-ResourceSharing/authoring/repository-structure.html)
 
 All the styles work with any polygon layer and you can try them out for example with [Natural Earth data](https://www.naturalearthdata.com/)

--- a/cls
+++ b/cls
@@ -1,0 +1,184 @@
+[33mcommit e3a09c844060a98e6a49b5e4ba1141548a6be426[m[33m ([m[1;36mHEAD -> [m[1;32mmaster[m[33m, [m[1;31morigin/master[m[33m, [m[1;31morigin/HEAD[m[33m)[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Thu Sep 30 09:41:19 2021 +0300
+
+    Update clock.xml
+
+[33mcommit 2a9abbfdaa75978191cc3f5cbd8eff65752150d8[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Mon Sep 20 09:41:34 2021 +0300
+
+    Create clock.xml
+
+[33mcommit 277f69adff4a19842ba79dee9036ce8669c9a5c0[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Tue Jul 13 14:59:50 2021 +0300
+
+    Update README.md
+
+[33mcommit 03c682251de09e5e6e0d5999ab190c8dc74cac7f[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Tue Jul 13 14:58:51 2021 +0300
+
+    Add kenya_kit sample image
+
+[33mcommit 1a594d082a2c0605f6c929b6884191dc20595b57[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Tue Jul 13 14:55:54 2021 +0300
+
+    Add Kenya Olympic Kit style
+
+[33mcommit 701d67640ff96f76a95591d57e6f34ed860485b6[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Fri Jul 3 14:41:30 2020 +0300
+
+    Updated readme with dormido markers
+
+[33mcommit 30cc7620e5c7213647adb0bff4e4456a3c7f240a[m
+Author: tjukanov <topi@gispo.fi>
+Date:   Fri Jul 3 14:39:26 2020 +0300
+
+    Added sample images for dormido
+
+[33mcommit cdeeaf78df0855f235afa81ccd4795cdf36342e7[m
+Author: tjukanov <topi@gispo.fi>
+Date:   Fri Jul 3 13:18:27 2020 +0300
+
+    Fine tuning on the dormido markers
+
+[33mcommit 7f8da158f055dced667a033f9505b2ed2b15bfc0[m
+Merge: abed695 4680f9b
+Author: tjukanov <topi@gispo.fi>
+Date:   Fri Jul 3 13:08:05 2020 +0300
+
+    Merge branch 'master' of https://github.com/tjukanovt/qgis_styles
+
+[33mcommit abed6954739acfe51300c72a9c69d8c22e3b3ea1[m
+Author: tjukanov <topi@gispo.fi>
+Date:   Fri Jul 3 13:07:06 2020 +0300
+
+    Added dormido markers
+
+[33mcommit 4680f9bafb014de704281803f95a44b41a0e12c4[m
+Merge: cacd29f 517f05d
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Tue Jun 30 08:09:01 2020 +0300
+
+    Merge pull request #1 from wboykinm/patch-1
+    
+    Fixing the natural earth data link
+
+[33mcommit 517f05d3e92cfa6dbc342b2aa91f98f44a325224[m
+Author: Bill Morris <wboykinm@geosprocket.com>
+Date:   Mon Jun 29 12:03:19 2020 -0400
+
+    Fixing the natural earth data link
+
+[33mcommit cacd29fe3018c128c8d3905114bbf85cc00132fd[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Mon Jun 29 13:27:12 2020 +0300
+
+    Readme fixes
+
+[33mcommit 7c260cada025202f9f9c303574603214b4ae896a[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Mon Jun 29 13:25:15 2020 +0300
+
+    Updated readme
+
+[33mcommit fc63ff93b44cec21d5b35743758782240247a348[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Mon Jun 29 13:24:09 2020 +0300
+
+    Updated readme with zebra
+
+[33mcommit 161dba714f4053337f18c4706e71503883bc82c3[m
+Author: tjukanov <topi@gispo.fi>
+Date:   Mon Jun 29 13:14:50 2020 +0300
+
+    Added zebra style
+
+[33mcommit 2476513449fae88ed081b16245ab1cd466740367[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Tue Jun 16 09:06:46 2020 +0300
+
+    Updated readme
+
+[33mcommit 89d792b335c0203c4b1d493dd6f0fa1ff726c228[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Tue Jun 16 09:05:01 2020 +0300
+
+    Fixed image sizes
+
+[33mcommit 251209b70fb633917be3f12bd14ce5e96f237082[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Tue Jun 16 09:04:03 2020 +0300
+
+    Updated readme
+
+[33mcommit 77decca108a71f134a14a2dfe19eb941a3bae6f3[m
+Author: tjukanov <topi@gispo.fi>
+Date:   Tue Jun 16 08:53:31 2020 +0300
+
+    Added mosaic image
+
+[33mcommit 61f8297dcbf9cf8bd5e3b63963419dfb9b1e617d[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Mon Jun 15 11:00:25 2020 +0300
+
+    Updated readme
+
+[33mcommit c5253dc631fe55efce2b1f7c70db7ee157f522fe[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Mon Jun 15 10:59:10 2020 +0300
+
+    Updated readme with sample images and instructions
+
+[33mcommit 5f4bce09cd5688b16591e3fa54142606eb271d66[m
+Merge: 8be6844 9d1a5a8
+Author: tjukanov <topi@gispo.fi>
+Date:   Mon Jun 15 10:58:20 2020 +0300
+
+    Merge branch 'master' of https://github.com/tjukanovt/qgis_styles
+
+[33mcommit 8be68443e1050166efc9a734ab4035fff58ae116[m
+Author: tjukanov <topi@gispo.fi>
+Date:   Mon Jun 15 10:56:20 2020 +0300
+
+    Added digital rain sample image
+
+[33mcommit 9d1a5a8e6abac939619063d82168a682b0623a86[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Mon Jun 15 10:50:13 2020 +0300
+
+    Updated readme
+
+[33mcommit 8c6b32a27f4f318ad2bf953633d60784c2df3153[m
+Author: tjukanov <topi@gispo.fi>
+Date:   Mon Jun 15 10:44:29 2020 +0300
+
+    Updated qlimt
+
+[33mcommit 8b7a5a8e91d064881abdf121e488f0c31442fea6[m
+Author: tjukanov <topi@gispo.fi>
+Date:   Mon Jun 15 10:22:22 2020 +0300
+
+    Added metadata + changed folder structure
+
+[33mcommit cdf0d11c2f92cc6287d60264a36561577840daac[m
+Author: tjukanov <topi@gispo.fi>
+Date:   Tue Jun 9 09:39:15 2020 +0300
+
+    Added sample images
+
+[33mcommit addba5874f44cdf55e9800f4deab88aeb8f49174[m
+Author: tjukanov <topi@gispo.fi>
+Date:   Tue Jun 9 09:16:33 2020 +0300
+
+    Initial commit with styles
+
+[33mcommit db45399ee98669b5f4462533024642222983d720[m
+Author: Topi Tjukanov <topi@gispo.fi>
+Date:   Tue Jun 9 09:13:48 2020 +0300
+
+    Initial commit


### PR DESCRIPTION
In the Readme file, the link of QGIS Resource Sharing plugin was not working. (Section: [How to use the styles in QGIS](https://github.com/tjukanovt/qgis_styles#how-to-use-the-styles-in-qgis)). I have updated the link. @tjukanovt please consider the issue.